### PR TITLE
Updated deprecated method for rails 7

### DIFF
--- a/lib/devise_revocable_session/models/revocable_session.rb
+++ b/lib/devise_revocable_session/models/revocable_session.rb
@@ -58,7 +58,7 @@ module Devise
         def devise_writer_wrapper
           role = Rails.application.config.active_record.writing_role || :writing
           ActiveRecord::Base.connected_to(role: role) do
-            ActiveRecord::Base.connection_handler.while_preventing_writes(false) do
+            ActiveRecord::Base.legacy_connection_handling.while_preventing_writes(false) do
               yield
             end
           end

--- a/lib/devise_revocable_session/version.rb
+++ b/lib/devise_revocable_session/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DeviseRevocableSession
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end


### PR DESCRIPTION
It looks like `ActiveRecord::Base` uses `legacy_connection_handling` now. 